### PR TITLE
randomvals~ -DMSP_VERSION=1 for msp target

### DIFF
--- a/random numbers/randomvals~/randomvals~.xcodeproj/project.pbxproj
+++ b/random numbers/randomvals~/randomvals~.xcodeproj/project.pbxproj
@@ -278,6 +278,10 @@
 				GCC_ENABLE_FIX_AND_CONTINUE = YES;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"MSP_VERSION=1",
+					"$(inherited)",
+				);
 				GCC_UNROLL_LOOPS = NO;
 			};
 			name = Development;
@@ -288,6 +292,10 @@
 				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				GCC_OPTIMIZATION_LEVEL = 3;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"MSP_VERSION=1",
+					"$(inherited)",
+				);
 				GCC_UNROLL_LOOPS = NO;
 			};
 			name = Deployment;
@@ -296,6 +304,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"MSP_VERSION=1",
+					"$(inherited)",
+				);
 				GCC_UNROLL_LOOPS = NO;
 			};
 			name = Default;


### PR DESCRIPTION
randomvals~ was not compiling properly because MSP_VERSION preprocessor macro not defined (unless I misunderstand your build system)